### PR TITLE
Papertrail logspout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 ## Changes
 
 
+### v0.0.2 on Mar 1, 2020
+
+* Added Logspout for Papertrail
+
+
 ### v0.0.1 on Feb 26, 2020
 
 * Initial release

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 An Ansible role to help configure Kubernetes clusters for web apps.
 
 Supported cloud providers include GCP (GKE), AWS (EKS), Azure (AKS), and Digital
-Ocean. The configuration includes installing the Nginx Ingress Controller and
-some Let's Encrypt certificate issuers so the team can focus on the application
-deployment itself.
+Ocean. The configuration includes installing:
+
+* Nginx Ingress Controller
+* Let's Encrypt certificate issuer
+* Logspout for Papertrail
 
 
 # License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,4 +13,4 @@ k8s_papertrail_logspout_enabled: "{{ k8s_papertrail_logspout_destination | lengt
 k8s_papertrail_logspout_destination: ''  # format: syslog+tls://logsN.papertrailapp.com:XXXXX
 k8s_papertrail_logspout_syslog_hostname: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.container.name" }}{% endraw %}'
 k8s_papertrail_logspout_syslog_tag: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]{% endraw %}'
-k8s_papertrail_logspout_namespace: 'default'
+k8s_papertrail_logspout_namespace: 'default'  # This namespace must exist already.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,6 @@ k8s_letsencrypt_email: ''
 k8s_echotest_state: present
 k8s_echotest_hostname: 'echotest.caktus-built.com'
 k8s_echotest_letsencrypt_issuer: 'letsencrypt-staging'
+
+k8s_papertrail_logspout_namespace: 'default'
+k8s_papertrail_logspout_destination: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ k8s_echotest_hostname: 'echotest.caktus-built.com'
 k8s_echotest_letsencrypt_issuer: 'letsencrypt-staging'
 
 k8s_papertrail_logspout_enabled: "{{ k8s_papertrail_logspout_destination | length > 0 }}"
-k8s_papertrail_logspout_destination: ''
+k8s_papertrail_logspout_destination: ''  # format: syslog+tls://logsN.papertrailapp.com:XXXXX
 k8s_papertrail_logspout_syslog_hostname: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.container.name" }}{% endraw %}'
 k8s_papertrail_logspout_syslog_tag: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]{% endraw %}'
 k8s_papertrail_logspout_namespace: 'default'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,5 +9,8 @@ k8s_echotest_state: present
 k8s_echotest_hostname: 'echotest.caktus-built.com'
 k8s_echotest_letsencrypt_issuer: 'letsencrypt-staging'
 
-k8s_papertrail_logspout_namespace: 'default'
+k8s_papertrail_logspout_enabled: "{{ k8s_papertrail_logspout_destination | length > 0 }}"
 k8s_papertrail_logspout_destination: ''
+k8s_papertrail_logspout_syslog_hostname: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.container.name" }}{% endraw %}'
+k8s_papertrail_logspout_syslog_tag: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]{% endraw %}'
+k8s_papertrail_logspout_namespace: 'default'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,3 +65,17 @@
     - ingress-nginx/cloud-generic.yaml
     - ingress-nginx/patch-configmap.yaml
   when: k8s_install_ingress_controller
+
+- name: Deploy Papertrail logspout
+  k8s:
+    context: "{{ k8s_context }}"
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    state: present
+    wait: yes
+    validate:
+      fail_on_error: yes
+      strict: yes
+    # Stored locally to convert to template
+    # https://help.papertrailapp.com/assets/files/papertrail-logspout-daemonset.yml
+    definition: "{{ lookup('template', 'papertrail/papertrail-logspout-daemonset.yml') }}"
+  when: k8s_papertrail_logspout_destination | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,7 +70,7 @@
   k8s:
     context: "{{ k8s_context }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
-    state: present
+    state: "{{ k8s_papertrail_logspout_enabled | ternary('present', 'absent') }}"
     wait: yes
     validate:
       fail_on_error: yes
@@ -78,4 +78,4 @@
     # Stored locally to convert to template
     # https://help.papertrailapp.com/assets/files/papertrail-logspout-daemonset.yml
     definition: "{{ lookup('template', 'papertrail/papertrail-logspout-daemonset.yml') }}"
-  when: k8s_papertrail_logspout_destination | length > 0
+  tags: [logspout]

--- a/templates/papertrail/papertrail-logspout-daemonset.yml
+++ b/templates/papertrail/papertrail-logspout-daemonset.yml
@@ -28,12 +28,10 @@ spec:
             limits:
               memory: 500Mi
           env:
-{% raw %}
             - name: SYSLOG_TAG
-              value: '{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]'
+              value: '{{ k8s_papertrail_logspout_syslog_tag }}'
             - name: SYSLOG_HOSTNAME
-              value: '{{ index .Container.Config.Labels "io.kubernetes.container.name" }}'
-{% endraw %}
+              value: '{{ k8s_papertrail_logspout_syslog_hostname }}'
             - name: ROUTE_URIS
               valueFrom:
                 secretKeyRef:

--- a/templates/papertrail/papertrail-logspout-daemonset.yml
+++ b/templates/papertrail/papertrail-logspout-daemonset.yml
@@ -1,3 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logspout-papertrail-secrets
+  namespace: '{{ k8s_papertrail_logspout_namespace }}'
+type: Opaque
+stringData:
+  papertrail-destination: '{{ k8s_papertrail_logspout_destination }}'
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -28,7 +37,7 @@ spec:
             - name: ROUTE_URIS
               valueFrom:
                 secretKeyRef:
-                  name: papertrail-destination
+                  name: logspout-papertrail-secrets
                   key: papertrail-destination
           image: gliderlabs/logspout:master
           name: logspout

--- a/templates/papertrail/papertrail-logspout-daemonset.yml
+++ b/templates/papertrail/papertrail-logspout-daemonset.yml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: echoserver
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echoserver
+  namespace: echoserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echoserver
+  template:
+    metadata:
+      labels:
+        app: echoserver
+    spec:
+      containers:
+      - image: gcr.io/google_containers/echoserver:1.10
+        imagePullPolicy: Always
+        name: echoserver
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoserver
+  namespace: echoserver
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: echoserver
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: echoserver
+  namespace: echoserver
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    certmanager.k8s.io/cluster-issuer: "{{ k8s_echotest_letsencrypt_issuer }}"
+spec:
+  tls:
+  - hosts:
+    - "{{ k8s_echotest_hostname }}"
+    secretName: echoserver-tls
+  rules:
+  - host: "{{ k8s_echotest_hostname }}"
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: echoserver
+          servicePort: 80

--- a/templates/papertrail/papertrail-logspout-daemonset.yml
+++ b/templates/papertrail/papertrail-logspout-daemonset.yml
@@ -1,61 +1,41 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: echoserver
----
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: echoserver
-  namespace: echoserver
+  name: logspout-papertrail
+  namespace: '{{ k8s_papertrail_logspout_namespace }}'
 spec:
-  replicas: 1
   selector:
     matchLabels:
-      app: echoserver
+      name: logspout-papertrail
   template:
     metadata:
       labels:
-        app: echoserver
+        name: logspout-papertrail
     spec:
       containers:
-      - image: gcr.io/google_containers/echoserver:1.10
-        imagePullPolicy: Always
-        name: echoserver
-        ports:
-        - containerPort: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: echoserver
-  namespace: echoserver
-spec:
-  ports:
-  - port: 80
-    targetPort: 8080
-    protocol: TCP
-  selector:
-    app: echoserver
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: echoserver
-  namespace: echoserver
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-    certmanager.k8s.io/cluster-issuer: "{{ k8s_echotest_letsencrypt_issuer }}"
-spec:
-  tls:
-  - hosts:
-    - "{{ k8s_echotest_hostname }}"
-    secretName: echoserver-tls
-  rules:
-  - host: "{{ k8s_echotest_hostname }}"
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: echoserver
-          servicePort: 80
+        - resources:
+            requests:
+              cpu: "0.15"
+            limits:
+              memory: 500Mi
+          env:
+{% raw %}
+            - name: SYSLOG_TAG
+              value: '{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]'
+            - name: SYSLOG_HOSTNAME
+              value: '{{ index .Container.Config.Labels "io.kubernetes.container.name" }}'
+{% endraw %}
+            - name: ROUTE_URIS
+              valueFrom:
+                secretKeyRef:
+                  name: papertrail-destination
+                  key: papertrail-destination
+          image: gliderlabs/logspout:master
+          name: logspout
+          volumeMounts:
+            - name: log
+              mountPath: /var/run/docker.sock
+      volumes:
+        - name: log
+          hostPath:
+              path: /var/run/docker.sock


### PR DESCRIPTION
Adds [Log from the standard Docker streams](https://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-kubernetes/) from Papertrail docs.