### PR TITLE
Create limited AWS IAM user for CI deploys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 * Re-enable validation in cert-manager workspace after installing or updating
   cert-manager and Lets Encrypt.
+* Support creation of an AWS IAM user with limited perms that can be used on CI to push
+  images and deploy.
 
 ### v0.0.2 on Mar 1, 2020
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Ocean. The configuration includes installing:
 * Certificate manager (https://cert-manager.io/docs/) (https://github.com/jetstack/cert-manager)
 * Let's Encrypt certificate issuer
 * Logspout for Papertrail
+* AWS IAM user with limited permissions for CI deploys
 
-
-# License
+## License
 
 This Ansible role is released under the BSD License. See the
 [LICENSE](https://github.com/caktus/ansible-role-k8s-web-cluster/blob/master/LICENSE)
@@ -20,12 +20,12 @@ file for more details.
 Development sponsored by [Caktus Consulting Group, LLC](http://www.caktusgroup.com/services>).
 
 
-# Requirements
+## Requirements
 
 * ``pip install openshift kubernetes-validate``
 
 
-# Installation
+## Installation
 
 1. Add to your ``requirements.yaml``:
 
@@ -35,7 +35,7 @@ Development sponsored by [Caktus Consulting Group, LLC](http://www.caktusgroup.c
 # file: deploy/requirements.yaml
 
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
-  version: init-role  # TODO: remove
+  version: 0.0.2
   name: caktus.k8s-web-cluster
 ```
 
@@ -71,6 +71,8 @@ k8s_echotest_hostname: <test hostname assigned to your cluster ip, e.g. echotest
 ansible-playbook -l <host/group> deploy.yaml -vv
 ```
 
+
+## Usage documentation
 
 ### Testing that Let's Encrypt is working
 
@@ -127,3 +129,38 @@ ansible-playbook -l <host/group> echotest.yaml -vv
 ```sh
 ansible-playbook -l <host/group> echotest.yaml --extra-vars "k8s_echotest_state=absent" -vv
 ```
+
+### Adding a limited AWS IAM user for CI deploys
+
+In order to be able to deploy to AWS from CI systems, you'll need to be able to
+authenticate as an IAM user that has the permissions to push to the AWS ECR (Docker
+registry), and possibly need to be able to read a secret from AWS Secrets Manager (the
+`.vault_pass` value). This playbook can create that user for you with the proper
+permissions. You can configure this with the following variables (defaults shown):
+
+```yaml
+k8s_ci_aws_profile: "default" # profile in your ~/.aws/credentials file, which will be used to create the user
+k8s_ci_username: ci-user
+k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:repository/<REPO_NAME>
+k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:secret:<NAME_OF_SECRET>
+```
+
+Only `k8s_ci_repository_arn` is required. The REPO_NAME portion can be found
+[here](https://console.aws.amazon.com/ecr/repositories). The
+`k8s_ci_aws_profile` value needs to be present in your `~/.aws/credentials` file and
+should correspond to an IAM user with sufficient permissions to create a user in the
+same AWS account where your k8s cluster lives. Finally, the `k8s_ci_vault_password_arn`
+is an optional pointer to a single secret in AWS Secrets Manager. The ARN can be found
+by going to this [link](https://console.aws.amazon.com/secretsmanager/home#/listSecrets)
+and then clicking on the secret you're sharing with the user. On some projects, we store
+the Ansible vault password in SecretsManager and then use an AWS CLI command to read the
+secret so other secrets in the repo can be decrypted. This allows the CI user to access
+that command.
+
+After you set those variables and run this role, the IAM user will be created with the
+proper permissions. You'll then need to use the AWS console to create an access key and
+secret key for that user. Take note of the `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` values.
+
+Copy those 2 variables (and `AWS_DEFAULT_REGION`) into the CI environment variables
+console.

--- a/README.md
+++ b/README.md
@@ -168,3 +168,9 @@ secret key for that user. Take note of the `AWS_ACCESS_KEY_ID` and
 
 Copy those 2 variables (and `AWS_DEFAULT_REGION`) into the CI environment variables
 console.
+
+NOTE: If you're using this with [the web app k8s
+role](https://github.com/caktus/ansible-role-django-k8s), be aware that you'll need to
+make sure that `k8s_rollout_after_deploy` is disabled (which is the default), because
+those commands don't currently use the service account user that this role depends on.
+See https://github.com/caktus/ansible-role-django-k8s/issues/25.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,9 @@ k8s_newrelic_enabled: "{{ k8s_newrelic_license_key | string | length > 0 }}"
 k8s_newrelic_kube_state_metrics_version: "v1.7.2"
 k8s_newrelic_cluster_name: "{{ k8s_context }}"
 k8s_newrelic_license_key: ""
+
+k8s_ci_create_user: "{{ k8s_ci_repository_arn | length > 0 }}"
+k8s_ci_aws_profile: default
+k8s_ci_username: ci-user
+k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:repository/<REPO_NAME>
+k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER:secret:<SECRET_IDENTIFIER>

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- when: (k8s_cluster_type != "aws") and k8s_ci_create_user
+  fail:
+    msg: "Setting k8s_ci_create_user is only supported on AWS"
+
 # cert-manager install process adapted from:
 # https://cert-manager.io/docs/installation/kubernetes/#installing-with-regular-manifests
 - name: Create namespace for cert-manager
@@ -132,3 +136,28 @@
     # https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration
     definition: "{{ lookup('template', 'newrelic/newrelic-infrastructure-k8s-latest.yaml') }}"
   tags: [metrics]
+
+- name: Create CI user
+  iam:
+    name: "{{ k8s_ci_username }}"
+    state: present
+    iam_type: user
+    profile: "{{ k8s_ci_aws_profile }}"
+  when: k8s_ci_create_user
+  register: ci_user
+
+- debug:
+    msg: |
+      IAM user {{ k8s_ci_username }} has been created.
+      Create an access_key in the AWS IAM console and store them in your CI's environment variables.
+  when: ci_user is changed
+
+- name: Attach inline policy to user
+  iam_policy:
+    iam_type: user
+    iam_name: "{{ k8s_ci_username }}"
+    policy_name: "ECRPush"
+    state: present
+    policy_json: "{{ lookup( 'template', 'aws/ECRPush.json.j2') }}"
+    profile: "{{ k8s_ci_aws_profile }}"
+  when: k8s_ci_create_user

--- a/templates/aws/ECRPush.json.j2
+++ b/templates/aws/ECRPush.json.j2
@@ -1,0 +1,49 @@
+{
+   "Version":"2012-10-17",
+   "Statement":[
+     {% if k8s_ci_vault_password_arn %}
+     {
+       {# https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html#description #}
+       "Sid":"ReadSecretVaultPassword",
+       "Effect":"Allow",
+       "Action":[
+         "secretsmanager:GetSecretValue",
+         "kms:Decrypt"
+       ],
+       "Resource":"{{ k8s_ci_vault_password_arn }}"
+     },
+     {% endif %}
+     {
+       "Sid":"GetAuthorizationToken",
+       "Effect":"Allow",
+       "Action":[
+         "ecr:GetAuthorizationToken"
+       ],
+       "Resource":"*"
+     },
+     {
+       {# https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html#AmazonEC2ContainerRegistryPowerUser #}
+       "Sid":"ManageRepositoryContents",
+       "Effect":"Allow",
+       "Action":[
+         "ecr:GetAuthorizationToken",
+         "ecr:BatchCheckLayerAvailability",
+         "ecr:GetDownloadUrlForLayer",
+         "ecr:GetRepositoryPolicy",
+         "ecr:DescribeRepositories",
+         "ecr:ListImages",
+         "ecr:DescribeImages",
+         "ecr:BatchGetImage",
+         "ecr:GetLifecyclePolicy",
+         "ecr:GetLifecyclePolicyPreview",
+         "ecr:ListTagsForResource",
+         "ecr:DescribeImageScanFindings",
+         "ecr:InitiateLayerUpload",
+         "ecr:UploadLayerPart",
+         "ecr:CompleteLayerUpload",
+         "ecr:PutImage"
+       ],
+       "Resource":"{{ k8s_ci_repository_arn }}"
+     }
+   ]
+}


### PR DESCRIPTION
I've tested this out on PW. I did have to turn `k8s_rollout_after_deploy` off (Should I mention that here in the docs?) 