### PR TITLE
Better Papertrail defaults?

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,8 +20,8 @@ k8s_echotest_letsencrypt_issuer: 'letsencrypt-staging'
 
 k8s_papertrail_logspout_enabled: "{{ k8s_papertrail_logspout_destination | length > 0 }}"
 k8s_papertrail_logspout_destination: ''  # format: syslog+tls://logsN.papertrailapp.com:XXXXX
-k8s_papertrail_logspout_syslog_hostname: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.container.name" }}{% endraw %}'
-k8s_papertrail_logspout_syslog_tag: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]{% endraw %}'
+k8s_papertrail_logspout_syslog_hostname: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}{% endraw %}'
+k8s_papertrail_logspout_syslog_tag: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.container.name" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]{% endraw %}'
 k8s_papertrail_logspout_namespace: 'default'  # This namespace must exist already.
 
 k8s_newrelic_enabled: "{{ k8s_newrelic_license_key | string | length > 0 }}"


### PR DESCRIPTION
This is based on working on exactly 1 k8s deployment, so feel free to not approve, but these defaults work better for the current project (PW) I'm working on and I'm wondering if they'd be better for all Caktus projects.

Pseudocode:
```
hostname: namespace
tag: container-name[pod-name]
```
* hostname is the first item in the log message, and setting this to the namespace means it looks either like `pw-staging` or `pw-production`, which is easy to group into a Papertrail Group.
* tag is the second item in the log message so this ends up looking like `celery-worker[celery-worker-ab2jf8]`. The container-name can be used to create "searches" and the pod name can be used if you're debugging things on a certain pod within a group.

Example output:
![image](https://user-images.githubusercontent.com/4413/85798808-2961fe80-b70c-11ea-912d-706c52cefadb.png)
