### PR TITLE
Allow papertrail memory limit to be configured

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ k8s_papertrail_logspout_destination: ''  # format: syslog+tls://logsN.papertrail
 k8s_papertrail_logspout_syslog_hostname: "{{ k8s_cluster_name }}"
 k8s_papertrail_logspout_syslog_tag: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]{% endraw %}'
 k8s_papertrail_logspout_namespace: 'default'  # This namespace must exist already.
+k8s_papertrail_logspout_memory_limit: 500Mi
 
 k8s_newrelic_enabled: "{{ k8s_newrelic_license_key | string | length > 0 }}"
 # Found under "the latest supported version"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ k8s_papertrail_logspout_destination: ''  # format: syslog+tls://logsN.papertrail
 k8s_papertrail_logspout_syslog_hostname: "{{ k8s_cluster_name }}"
 k8s_papertrail_logspout_syslog_tag: '{% raw %}{{ index .Container.Config.Labels "io.kubernetes.pod.namespace" }}[{{ index .Container.Config.Labels "io.kubernetes.pod.name" }}]{% endraw %}'
 k8s_papertrail_logspout_namespace: 'default'  # This namespace must exist already.
+k8s_papertrail_logspout_memory_request: 50Mi
 k8s_papertrail_logspout_memory_limit: 500Mi
 
 k8s_newrelic_enabled: "{{ k8s_newrelic_license_key | string | length > 0 }}"

--- a/templates/papertrail/papertrail-logspout-daemonset.yml
+++ b/templates/papertrail/papertrail-logspout-daemonset.yml
@@ -25,8 +25,9 @@ spec:
         - resources:
             requests:
               cpu: "0.15"
+              memory: "50Mi"
             limits:
-              memory: 500Mi
+              memory: '{{ k8s_papertrail_logspout_memory_limit }}'
           env:
             - name: SYSLOG_TAG
               value: '{{ k8s_papertrail_logspout_syslog_tag }}'

--- a/templates/papertrail/papertrail-logspout-daemonset.yml
+++ b/templates/papertrail/papertrail-logspout-daemonset.yml
@@ -25,7 +25,7 @@ spec:
         - resources:
             requests:
               cpu: "0.15"
-              memory: "50Mi"
+              memory: '{{ k8s_papertrail_logspout_memory_request }}'
             limits:
               memory: '{{ k8s_papertrail_logspout_memory_limit }}'
           env:


### PR DESCRIPTION
Papertrail takes up to 500mb of RAM on each node, which is quite restricting on 2G RAM machines. This allows that limit to be configurable. It also sets the memory request to be a smaller amount, since logspout reportedly can run with much lower requirements. So, we start with a 50mb request, but allow logspout to use up to 500mb, if needed.

I left the default limit at 500mb for backwards compatibility, but maybe it makes sense to drop it here (to 256 or 128 mb) and just document that existing projects should inspect their current usage?