### PR TITLE
Update newrelic-infra

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ k8s_papertrail_logspout_memory_limit: 500Mi
 k8s_newrelic_enabled: "{{ k8s_newrelic_license_key | string | length > 0 }}"
 # Found under "the latest supported version"
 # https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#install
-k8s_newrelic_kube_state_metrics_version: "v1.7.2"
+k8s_newrelic_kube_state_metrics_version: "v1.9.7"
 k8s_newrelic_cluster_name: "{{ k8s_cluster_name }}"
 k8s_newrelic_license_key: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ k8s_newrelic_enabled: "{{ k8s_newrelic_license_key | string | length > 0 }}"
 k8s_newrelic_kube_state_metrics_version: "v1.9.7"
 k8s_newrelic_cluster_name: "{{ k8s_cluster_name }}"
 k8s_newrelic_license_key: ""
+k8s_newrelic_namespace: "newrelic-infra"
 
 # For AWS, IAM users that should have access to the cluster (i.e., those users
 # who should be able to run `aws eks update-kubeconfig`). Users' access *will* be removed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,9 +137,11 @@
       fail_on_error: yes
       strict: yes
     # Stored locally to convert to template
+    # https://download.newrelic.com/infrastructure_agent/integrations/kubernetes/newrelic-infrastructure-k8s-latest.yaml
+    # Docs:
     # https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration
     definition: "{{ lookup('template', 'newrelic/newrelic-infrastructure-k8s-latest.yaml') }}"
-  tags: [metrics]
+  tags: [newrelic-infra]
 
 - name: Grant access to IAM users if aws
   when: k8s_cluster_type == "aws"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,11 +121,11 @@
     definition: "{{ lookup('url', item, split_lines=False) }}"
   tags: [metrics]
   with_items:
-  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/kubernetes/kube-state-metrics-cluster-role-binding.yaml"
-  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/kubernetes/kube-state-metrics-cluster-role.yaml"
-  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/kubernetes/kube-state-metrics-service-account.yaml"
-  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/kubernetes/kube-state-metrics-deployment.yaml"
-  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/kubernetes/kube-state-metrics-service.yaml"
+  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/examples/standard/cluster-role-binding.yaml"
+  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/examples/standard/cluster-role.yaml"
+  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/examples/standard/service-account.yaml"
+  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/examples/standard/deployment.yaml"
+  - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/examples/standard/service.yaml"
 
 - name: Install New Relic Infrastructure Agent
   k8s:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,6 +127,23 @@
   - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/examples/standard/deployment.yaml"
   - "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/{{ k8s_newrelic_kube_state_metrics_version }}/examples/standard/service.yaml"
 
+- name: Create namespace for New Relic Infrastructure Agent
+  when: k8s_newrelic_namespace != "default"
+  k8s:
+    context: "{{ k8s_context|mandatory }}"
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    state: "{{ k8s_newrelic_enabled | ternary('present', 'absent') }}"
+    wait: yes
+    validate:
+      fail_on_error: yes
+      strict: yes
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ k8s_newrelic_namespace }}"
+  tags: [newrelic-infra]
+
 - name: Install New Relic Infrastructure Agent
   k8s:
     context: "{{ k8s_context }}"

--- a/templates/newrelic/newrelic-infrastructure-k8s-latest.yaml
+++ b/templates/newrelic/newrelic-infrastructure-k8s-latest.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: newrelic
-  namespace: default
+  namespace: "{{ k8s_newrelic_namespace }}"
 automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,13 +35,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: newrelic
-  namespace: default
+  namespace: "{{ k8s_newrelic_namespace }}"
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nri-default-integration-cfg # integrations config provided by default
-  namespace: default
+  namespace: "{{ k8s_newrelic_namespace }}"
 data:
   nri-kubernetes-config.yml: |
     integration_name: com.newrelic.kubernetes
@@ -53,13 +53,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nri-integration-cfg # aimed to be safely overridden by users
-  namespace: default
+  namespace: "{{ k8s_newrelic_namespace }}"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: newrelic-infra
-  namespace: default
+  namespace: "{{ k8s_newrelic_namespace }}"
   labels:
     app: newrelic-infra
 spec:

--- a/templates/newrelic/newrelic-infrastructure-k8s-latest.yaml
+++ b/templates/newrelic/newrelic-infrastructure-k8s-latest.yaml
@@ -67,22 +67,18 @@ spec:
     matchLabels:
       name: newrelic-infra
   updateStrategy:
-      type: RollingUpdate # Only supported in Kubernetes version 1.6 or later.
+      type: RollingUpdate
   template:
     metadata:
       labels:
         name: newrelic-infra
-      annotations:
-        # Needed for Kubernetes versions prior to 1.6.0, where tolerations were set via annotations.
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"operator": "Exists", "effect": "NoSchedule"},{"operator": "Exists", "effect": "NoExecute"}]
     spec:
       serviceAccountName: newrelic
       hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: newrelic-infra
-          image: newrelic/infrastructure-k8s:1.17.0
+          image: newrelic/infrastructure-k8s:1.26.2
           securityContext:
             privileged: true
           resources:
@@ -146,7 +142,7 @@ spec:
             - name: "NRIA_CUSTOM_ATTRIBUTES"
               value: '{"clusterName":"$(CLUSTER_NAME)"}'
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
-              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,KUBE_STATE_METRICS_POD_LABEL,ETCD_TLS_SECRET_NAME,ETCD_TLS_SECRET_NAMESPACE,API_SERVER_SECURE_PORT,KUBE_STATE_METRICS_SCHEME,KUBE_STATE_METRICS_PORT,SCHEDULER_ENDPOINT_URL,ETCD_ENDPOINT_URL,CONTROLLER_MANAGER_ENDPOINT_URL,API_SERVER_ENDPOINT_URL,DISABLE_KUBE_STATE_METRICS"
+              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,KUBE_STATE_METRICS_POD_LABEL,ETCD_TLS_SECRET_NAME,ETCD_TLS_SECRET_NAMESPACE,API_SERVER_SECURE_PORT,KUBE_STATE_METRICS_SCHEME,KUBE_STATE_METRICS_PORT,SCHEDULER_ENDPOINT_URL,ETCD_ENDPOINT_URL,CONTROLLER_MANAGER_ENDPOINT_URL,API_SERVER_ENDPOINT_URL,DISABLE_KUBE_STATE_METRICS,NETWORK_ROUTE_FILE"
       volumes:
         - name: host-volume
           hostPath:


### PR DESCRIPTION
New Relic appears to only support [kube-state-metrics v1.9.x](https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure#customized-manifest) currently.

Included:
* Update GitHub paths for ``kube-state-metrics`` yaml files > v1.7.2
* Set default ``k8s_newrelic_kube_state_metrics_version`` to **v1.9.7**
* Update newrelic-infra ``DaemonSet``
* Allow customization of newrelic-infra ``namespace``

To update:
* Before updating, uninstall NR/kube-state-metrics by invoking **caktus.k8s-web-cluster** with ``k8s_newrelic_license_key`` unset, which will delete all related resources
* Update to the new version of **caktus.k8s-web-cluster** and invoke the role again with ``k8s_newrelic_license_key`` set