### PR TITLE
Add nginx-errors default backend for error customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,28 @@ role](https://github.com/caktus/ansible-role-django-k8s), be aware that you'll n
 make sure that `k8s_rollout_after_deploy` is disabled (which is the default), because
 those commands don't currently use the service account user that this role depends on.
 See https://github.com/caktus/ansible-role-django-k8s/issues/25.
+
+### Customize Nginx Error Pages
+
+This role will create a service (and deployment) named `nginx-errors` in the
+`ingress-nginx` namespace. That service will run a pod using the image specified in
+`k8s_nginx_errors_image`. This defaults to an [image built
+here](https://github.com/caktus/custom-error-pages), which provides an image that
+returns a customized 503 error page. The main purpose for this is to allow you to turn
+on a maintenance page. In the kubernetes world, a maintenance page is rarely needed but
+there are times where you might want one. For example, if you are upgrading the database
+and just want to turn off web access to the DB for a short time. Since all 503 errors
+will return the custom 503 maintenance page, you could do this:
+
+```bash
+kubectl scale deployment -n <my-namespace> --replicas=0 --all
+```
+
+That would turn off all your apps, and nginx would serve your maintenance page. Then,
+when you restarted things (by setting `--replicas=N`), the maintenance page would go
+away.
+
+If you want to customize the 503 page, or if you want to add custom pages for any other
+nginx error code, you'll need to clone the https://github.com/caktus/custom-error-pages
+repo, create new HTML pages there, and then refer to your image in
+`k8s_nginx_errors_image`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,6 @@ k8s_ci_aws_profile: default
 k8s_ci_username: ci-user
 k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:repository/<REPO_NAME>
 k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER:secret:<SECRET_IDENTIFIER>
+
+k8s_nginx_errors_codes: "503" # CSV of error codes to intercept
+k8s_nginx_errors_image: "ghcr.io/caktus/custom-error-pages:latest"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,4 +50,4 @@ k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:reposi
 k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER:secret:<SECRET_IDENTIFIER>
 
 k8s_nginx_errors_codes: "503" # CSV of error codes to intercept
-k8s_nginx_errors_image: "ghcr.io/caktus/custom-error-pages:latest"
+k8s_nginx_errors_image: "ghcr.io/caktus/custom-error-pages:1.0"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,6 +89,7 @@
       strict: yes
     definition: "{{ lookup('template', item) }}"
   with_items:
+    - ingress-nginx/nginx-errors.yaml.j2
     - ingress-nginx/mandatory.yaml
     - ingress-nginx/cloud-generic.yaml
     - ingress-nginx/patch-configmap.yaml

--- a/templates/ingress-nginx/mandatory.yaml
+++ b/templates/ingress-nginx/mandatory.yaml
@@ -223,6 +223,7 @@ spec:
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
             - --publish-service=$(POD_NAMESPACE)/ingress-nginx
             - --annotations-prefix=nginx.ingress.kubernetes.io
+            - --default-backend-service=$(POD_NAMESPACE)/nginx-errors
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:

--- a/templates/ingress-nginx/nginx-errors.yaml.j2
+++ b/templates/ingress-nginx/nginx-errors.yaml.j2
@@ -1,0 +1,44 @@
+{# Taken from: https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-errors #}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-errors
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: nginx-errors
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  selector:
+    app.kubernetes.io/name: nginx-errors
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+  - port: 80
+    targetPort: 8080
+    name: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-errors
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: nginx-errors
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-errors
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-errors
+        app.kubernetes.io/part-of: ingress-nginx
+    spec:
+      containers:
+      - name: nginx-error-server
+        image: "{{ k8s_nginx_errors_image }}"
+        ports:
+        - containerPort: 8080

--- a/templates/ingress-nginx/patch-configmap.yaml
+++ b/templates/ingress-nginx/patch-configmap.yaml
@@ -7,4 +7,5 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
 data:
-  use-proxy-protocol: "{% if k8s_cluster_type in ("digitalocean", "aws") %}true{% else %}false{% endif %}"
+  use-proxy-protocol: "{% if k8s_cluster_type in ('digitalocean', 'aws') %}true{% else %}false{% endif %}"
+  custom-http-errors: "{{ k8s_nginx_errors_codes }}"


### PR DESCRIPTION
This follows the guide(s) here:
* https://kubernetes.github.io/ingress-nginx/examples/customization/custom-errors/
* https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-errors

... to allow customization of the error pages that nginx serves.

We only use it for 503 errors because the other 2 common errors (404 and 500) are usually handled by Django.

Why is this useful? Now you can do:

```
kubectl scale deployment -n <my-namespace> --replicas=0 --all
```

... and then your environment will start serving the custom 503 page, rather than the default nginx 503 error page. In our case we show a page saying that we are undergoing maintenance. The main use-case would be do to do DB maintenance, as we want to do in the case of pressweb when we load the old DB into the new prod RDS instance without having to worry about concurrent new information being added to the DB from the app.

I have not created a flag to turn this on or off because I think it is safe to turn it on for all existing caktus k8s projects, but I could do that if desired.

~I should change the tag of the image to be a version number rather than `latest`, but wanted to get this out there for review. I will make that change before merging.~ Completed in commit 2