### PR TITLE
Add default replica count and fix typo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ k8s_purge_ingress_controller: no
 # https://github.com/kubernetes/ingress-nginx/releases
 k8s_ingress_nginx_chart_version: "3.23.0"
 k8s_ingress_nginx_namespace: ingress-nginx
+k8s_ingress_nginx_replica_count: 2
 
 # cert-manager settings
 k8s_install_cert_manager: yes

--- a/templates/ingress-nginx/chart-values-aws.yaml
+++ b/templates/ingress-nginx/chart-values-aws.yaml
@@ -27,3 +27,4 @@ controller:
     # Enable PROXY protocol in Nginx
     use-proxy-protocol: "true"
 {% endif %}
+  replicaCount: {{ k8s_ingress_nginx_replica_count }}

--- a/templates/ingress-nginx/chart-values-azure.yaml
+++ b/templates/ingress-nginx/chart-values-azure.yaml
@@ -1,2 +1,4 @@
 # Reference for values accepted by the ingress-nginx chart:
 # https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/values.yaml
+controller:
+  replicaCount: {{ k8s_ingress_nginx_replica_count }}

--- a/templates/ingress-nginx/chart-values-digitalocean.yaml
+++ b/templates/ingress-nginx/chart-values-digitalocean.yaml
@@ -4,14 +4,15 @@ controller:
   service:
     annotations:
       # Enable PROXY protocol on the load balancer
-      service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "{% if k8s_digitalocean_loadbalancer_hostname %}true{% else %}false{% endif %}"
+      service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "{% if k8s_digitalocean_load_balancer_hostname %}true{% else %}false{% endif %}"
       # Digital Ocean load balancers must be accessed by hostname if PROXY protocol is enabled, since
       # cert-manager verifications requires pods to be able to reach the cluster via the LoadBalancer
       # address. See:
       # https://www.digitalocean.com/docs/kubernetes/how-to/configure-load-balancers/#accessing-by-hostname-annotation
-{% if k8s_digitalocean_loadbalancer_hostname %}
-      service.beta.kubernetes.io/do-loadbalancer-hostname: "{{ k8s_digitalocean_loadbalancer_hostname }}"
+{% if k8s_digitalocean_load_balancer_hostname %}
+      service.beta.kubernetes.io/do-loadbalancer-hostname: "{{ k8s_digitalocean_load_balancer_hostname }}"
 {% endif %}
   config:
     # Enable PROXY protocol in Nginx
-    use-proxy-protocol: "{% if k8s_digitalocean_loadbalancer_hostname %}true{% else %}false{% endif %}"
+    use-proxy-protocol: "{% if k8s_digitalocean_load_balancer_hostname %}true{% else %}false{% endif %}"
+  replicaCount: {{ k8s_ingress_nginx_replica_count }}

--- a/templates/ingress-nginx/chart-values-gcp.yaml
+++ b/templates/ingress-nginx/chart-values-gcp.yaml
@@ -1,2 +1,4 @@
 # Reference for values accepted by the ingress-nginx chart:
 # https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/values.yaml
+controller:
+  replicaCount: {{ k8s_ingress_nginx_replica_count }}


### PR DESCRIPTION
- default to 2 replicas for ingress controller
- fix typo in `k8s_digitalocean_load_balancer_hostname`
