### PR TITLE
Add `k8s_ingress_class`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ k8s_purge_ingress_controller: no
 k8s_ingress_nginx_chart_version: "3.23.0"
 k8s_ingress_nginx_namespace: ingress-nginx
 k8s_ingress_nginx_replica_count: 2
+k8s_ingress_class: ngnix
 
 # cert-manager settings
 k8s_install_cert_manager: yes

--- a/templates/letsencrypt/issuers.yaml
+++ b/templates/letsencrypt/issuers.yaml
@@ -16,7 +16,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: "{{ k8s_ingress_class }}"
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -36,4 +36,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: "{{ k8s_ingress_class }}"


### PR DESCRIPTION
Allow override of `http01.ingress.class` via `k8s_cert_manager_ingress_class`. To use with microk8s, set `k8s_cert_manager_ingress_class = public` so cert-manager will work (ubuntu/microk8s#1890).