### PR TITLE
Support Configuring DNS01 Challenge Provider

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,13 @@ k8s_purge_cert_manager: no
 # https://github.com/jetstack/cert-manager/releases
 k8s_cert_manager_chart_version: "v1.2.0"
 k8s_cert_manager_namespace: cert-manager
+k8s_cert_manager_http01_solver:
+  http01:
+    ingress:
+      class: "{{ k8s_ingress_class }}"
+# Add a single challenge solver by default, HTTP01 using nginx
+k8s_cert_manager_solvers:
+  - "{{ k8s_cert_manager_http01_solver }}"
 
 
 # Let's Encrypt will use this to contact you about expiring

--- a/templates/echotest.yml
+++ b/templates/echotest.yml
@@ -38,13 +38,13 @@ spec:
   selector:
     app: echoserver
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echoserver
   namespace: echoserver
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "{{ k8s_ingress_class }}"
     cert-manager.io/cluster-issuer:  "{{ k8s_echotest_letsencrypt_issuer }}"
 spec:
   tls:
@@ -56,6 +56,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: echoserver
-          servicePort: 80
+          service:
+            name: echoserver
+            port:
+              number: 80

--- a/templates/letsencrypt/issuers.yaml
+++ b/templates/letsencrypt/issuers.yaml
@@ -12,11 +12,8 @@ spec:
     privateKeySecretRef:
       # Secret resource used to store the account's private key.
       name: letsencrypt-staging-account-key
-    # Add a single challenge solver, HTTP01 using nginx
-    solvers:
-    - http01:
-        ingress:
-          class: "{{ k8s_ingress_class }}"
+    solvers: "{{ k8s_cert_manager_solvers | to_json }}"
+
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -32,8 +29,4 @@ spec:
     privateKeySecretRef:
       # Secret resource used to store the account's private key.
       name: letsencrypt-production-account-key
-    # Add a single challenge solver, HTTP01 using nginx
-    solvers:
-    - http01:
-        ingress:
-          class: "{{ k8s_ingress_class }}"
+    solvers: "{{ k8s_cert_manager_solvers | to_json }}"

--- a/templates/letsencrypt/issuers.yaml
+++ b/templates/letsencrypt/issuers.yaml
@@ -12,8 +12,7 @@ spec:
     privateKeySecretRef:
       # Secret resource used to store the account's private key.
       name: letsencrypt-staging-account-key
-    solvers: "{{ k8s_cert_manager_solvers | to_json }}"
-
+    solvers: {{ k8s_cert_manager_solvers | to_json }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -29,4 +28,4 @@ spec:
     privateKeySecretRef:
       # Secret resource used to store the account's private key.
       name: letsencrypt-production-account-key
-    solvers: "{{ k8s_cert_manager_solvers | to_json }}"
+    solvers: {{ k8s_cert_manager_solvers | to_json }}


### PR DESCRIPTION
Support using Acme DNS01 as an alternative to HTTP01. See [Configuring DNS01 Challenge Provider](https://cert-manager.io/docs/configuration/acme/dns01/)