### PR TITLE
Ansible 6.x support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ This project uses [semantic versioning](https://semver.org/).
 
 ## Changes
 
+### v1.5.0 on March 9, 2023
+* **Requires Ansible v6.0+**
+* Switch to `kubernetes.core` for Ansible 6.x+ support. The `community.kubernetes` collection was renamed to `kubernetes.core` in [v2.0.0 of the kubernetes.core collection](https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst#v2-0-0). Since [Ansible v3.0.0](https://github.com/ansible-community/ansible-build-data/blob/main/3/CHANGELOG-v3.rst#included-collections), both the `kubernetes.core` and `community.kubernetes` namespaced collections were included for convenience. [Ansible v6.0.0](https://github.com/ansible-community/ansible-build-data/blob/f3602822e899015312852bb3e2debe52df109135/6/CHANGELOG-v6.rst#L4281) removed the `community.kubernetes` convenience package.
+* Use [fully qualified collection names (FQCNs)](https://github.com/ansible-collections/overview/blob/4e7fdd2512a4ec213b1beccef3b58dfb58b0d06e/README.rst#terminology) to be explicit
+
 ### v1.4.0 on February 8th, 2023
 * Add optional [Descheduler for Kubernetes](https://github.com/kubernetes-sigs/descheduler/) support. Enable with `k8s_install_descheduler` and reference `defaults/main.yml` for configuration options.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,11 @@ This project uses [semantic versioning](https://semver.org/).
 
 ## Changes
 
-### v1.5.0 on March 9, 2023
+### v1.5.0 on April 11, 2023
 * **Requires Ansible v6.0+**
 * Switch to `kubernetes.core` for Ansible 6.x+ support. The `community.kubernetes` collection was renamed to `kubernetes.core` in [v2.0.0 of the kubernetes.core collection](https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst#v2-0-0). Since [Ansible v3.0.0](https://github.com/ansible-community/ansible-build-data/blob/main/3/CHANGELOG-v3.rst#included-collections), both the `kubernetes.core` and `community.kubernetes` namespaced collections were included for convenience. [Ansible v6.0.0](https://github.com/ansible-community/ansible-build-data/blob/f3602822e899015312852bb3e2debe52df109135/6/CHANGELOG-v6.rst#L4281) removed the `community.kubernetes` convenience package.
 * Use [fully qualified collection names (FQCNs)](https://github.com/ansible-collections/overview/blob/4e7fdd2512a4ec213b1beccef3b58dfb58b0d06e/README.rst#terminology) to be explicit
+* Add ``k8s_cert_manager_release_values`` variable to allow per-project customization of Helm chart values
 
 ### v1.4.0 on February 8th, 2023
 * Add optional [Descheduler for Kubernetes](https://github.com/kubernetes-sigs/descheduler/) support. Enable with `k8s_install_descheduler` and reference `defaults/main.yml` for configuration options.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Development sponsored by [Caktus Consulting Group, LLC](http://www.caktusgroup.c
 
 ## Requirements
 
+* Ansible v6.0+
 * ``pip install openshift kubernetes-validate``
 * [helm](https://helm.sh/docs/intro/install/)
   * *Important:* The version must be [supported by](https://helm.sh/docs/topics/version_skew/#supported-version-skew) the current Kubernetes cluster version.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,9 @@ k8s_cert_manager_http01_solver:
 # Add a single challenge solver by default, HTTP01 using nginx
 k8s_cert_manager_solvers:
   - "{{ k8s_cert_manager_http01_solver }}"
-
+# https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
+k8s_cert_manager_release_values:
+  installCRDs: "true"
 
 # Let's Encrypt will use this to contact you about expiring
 # certificates, and issues related to your account.

--- a/tasks/echotest.yml
+++ b/tasks/echotest.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install echotest
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_echotest_state }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 # Sanity check so we don't accidentally remove all access to the cluster on AWS:
 - when: (k8s_cluster_type == "aws") and (k8s_iam_users|length == 0)
-  fail:
+  ansible.builtin.fail:
     msg: "Set k8s_iam_users to a list of IAM usernames who should have access to manage the cluster"
 
 - name: Remove cert-manager
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     wait: yes
@@ -14,7 +14,7 @@
   when: k8s_purge_cert_manager
 
 - name: Remove ingress-nginx
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     wait: yes
@@ -84,7 +84,7 @@
   when: k8s_install_cert_manager
 
 - name: Deploy Let's Encrypt issuers
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     wait: yes
@@ -98,7 +98,7 @@
 
 - name: Grant access to IAM users if aws
   when: k8s_cluster_type == "aws"
-  k8s:
+  kubernetes.core.k8s:
     definition: "{{ lookup('template', 'aws/cluster-auth.yaml') }}"
     context: "{{ k8s_context }}"
     kubeconfig: "{{ k8s_kubeconfig }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   when: k8s_purge_ingress_controller
 
 - name: Apply Descheduler Helm chart
-  community.kubernetes.helm:
+  kubernetes.core.helm:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     chart_repo_url: https://kubernetes-sigs.github.io/descheduler/
@@ -36,7 +36,7 @@
   when: k8s_install_descheduler
 
 - name: Create ingress-nginx namespace
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     name: "{{ k8s_ingress_nginx_namespace }}"
@@ -46,7 +46,7 @@
   when: k8s_install_ingress_controller
 
 - name: Create cert-manager namespace
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     name: "{{ k8s_cert_manager_namespace }}"
@@ -56,7 +56,7 @@
   when: k8s_install_cert_manager
 
 - name: Add ingress-nginx Helm chart
-  community.kubernetes.helm:
+  kubernetes.core.helm:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     chart_repo_url: "https://kubernetes.github.io/ingress-nginx"
@@ -70,7 +70,7 @@
   when: k8s_install_ingress_controller
 
 - name: Add cert-manager Helm chart
-  community.kubernetes.helm:
+  kubernetes.core.helm:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     chart_repo_url: "https://charts.jetstack.io"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,8 +78,7 @@
     chart_version: "{{ k8s_cert_manager_chart_version }}"
     release_name: cert-manager
     release_namespace: "{{ k8s_cert_manager_namespace }}"
-    release_values:
-      installCRDs: "true"
+    release_values: "{{ k8s_cert_manager_release_values }}"
     wait: yes
   when: k8s_install_cert_manager
 


### PR DESCRIPTION
### Summary
* Switch to `kubernetes.core` for Ansible 6.x+ support. The `community.kubernetes` collection was renamed to `kubernetes.core` in [v2.0.0 of the kubernetes.core collection](https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst#v2-0-0). Since [Ansible v3.0.0](https://github.com/ansible-community/ansible-build-data/blob/main/3/CHANGELOG-v3.rst#included-collections), both the `kubernetes.core` and `community.kubernetes` namespaced collections were included for convenience. [Ansible v6.0.0](https://github.com/ansible-community/ansible-build-data/blob/f3602822e899015312852bb3e2debe52df109135/6/CHANGELOG-v6.rst#L4281) removed the `community.kubernetes` convenience package.
* Use [fully qualified collection names (FQCNs)](https://github.com/ansible-collections/overview/blob/4e7fdd2512a4ec213b1beccef3b58dfb58b0d06e/README.rst#terminology) to be explicit
* Add ``k8s_cert_manager_release_values`` variable to allow per-project customization of Helm chart values