### PR TITLE
Add support for loadBalancerSourceRanges in the AWS NLB configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ This project uses [semantic versioning](https://semver.org/).
 
 ## Changes
 
+### v1.8.0 on May 16th, 2025
+* Add support for [`loadBalancerSourceRanges`](https://github.com/kubernetes/ingress-nginx/blob/d3ab5efd54f38f2b7c961024553b0ad060e2e916/charts/ingress-nginx/values.yaml#L512-L513) in the AWS NLB configuration, allowing for more granular control over which IP ranges can access the load balancer.
+
 ### v1.7.0 on December 5th, 2024
 * Use boolean type for `installCRDs` cert-manager value to support [v1.15.0+](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0). Eventually, this value should be migrated to `crds.keep: true` and `crds.enabled: true`.
 

--- a/templates/ingress-nginx/chart-values-aws.yaml
+++ b/templates/ingress-nginx/chart-values-aws.yaml
@@ -7,6 +7,9 @@ controller:
 {% if k8s_ingress_nginx_load_balancer_ip is defined %}
     loadBalancerIP: "{{ k8s_ingress_nginx_load_balancer_ip }}"
 {% endif %}
+{% if k8s_ingress_nginx_load_balancer_source_ranges is defined %}
+    loadBalancerSourceRanges: {{ k8s_ingress_nginx_load_balancer_source_ranges | to_json }}
+{% endif %}
 {% if k8s_aws_load_balancer_type == "nlb" %}
     # Adapted from the NLB configuration for the non-Helm install (for some reason NLB
     # is not yet the default for Helm installs):


### PR DESCRIPTION
Support restricting traffic to the load balancer to a specific CIDR range by setting `k8s_ingress_nginx_load_balancer_source_ranges` to a list of CIDR ranges. This is useful for security purposes, especially in environments where you want to limit access to the load balancer to specific IP ranges.