### PR TITLE
Support the annotations-risk-level controller value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ This project uses [semantic versioning](https://semver.org/).
 
 ## Changes
 
+### v1.9.0 on July ???, 2025
+* Add support for [`annotations-risk-level`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#annotations-risk-level) in the ingress-nginx controller.
+
 ### v1.8.0 on May 20th, 2025
 * Add support for [`loadBalancerSourceRanges`](https://github.com/kubernetes/ingress-nginx/blob/d3ab5efd54f38f2b7c961024553b0ad060e2e916/charts/ingress-nginx/values.yaml#L512-L513) in the AWS NLB configuration, allowing for more granular control over which IP ranges can access the load balancer.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,6 +68,9 @@ k8s_ingress_nginx_affinity:
         topologyKey: kubernetes.io/hostname
 # Optionally set the loadBalancerIP of the Service (if supported by the provider):
 # k8s_ingress_nginx_load_balancer_ip: w.x.y.z
+# https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#annotations-risk-level
+# <Critical|High|Medium|Low>
+k8s_ingress_nginx_load_balancer_annotations_risk_level: "High"
 
 # cert-manager settings
 k8s_install_cert_manager: yes

--- a/templates/ingress-nginx/chart-values-aws.yaml
+++ b/templates/ingress-nginx/chart-values-aws.yaml
@@ -19,6 +19,8 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    config:
+      annotations-risk-level: "{{ k8s_ingress_nginx_load_balancer_annotations_risk_level }}"
 {% else %}
     # For projects that still wish to use it, also support Classic (ELB) load balancers:
     externalTrafficPolicy: Cluster
@@ -34,5 +36,6 @@ controller:
   config:
     # Enable PROXY protocol in Nginx
     use-proxy-protocol: "true"
+    annotations-risk-level: "{{ k8s_ingress_nginx_load_balancer_annotations_risk_level }}"
 {% endif %}
   replicaCount: {{ k8s_ingress_nginx_replica_count }}

--- a/templates/ingress-nginx/chart-values-azure.yaml
+++ b/templates/ingress-nginx/chart-values-azure.yaml
@@ -7,4 +7,6 @@ controller:
   service:
     loadBalancerIP: "{{ k8s_ingress_nginx_load_balancer_ip }}"
 {% endif %}
+  config:
+    annotations-risk-level: "{{ k8s_ingress_nginx_load_balancer_annotations_risk_level }}"
   replicaCount: {{ k8s_ingress_nginx_replica_count }}

--- a/templates/ingress-nginx/chart-values-digitalocean.yaml
+++ b/templates/ingress-nginx/chart-values-digitalocean.yaml
@@ -20,4 +20,5 @@ controller:
   config:
     # Enable PROXY protocol in Nginx
     use-proxy-protocol: "{% if k8s_digitalocean_load_balancer_hostname %}true{% else %}false{% endif %}"
+    annotations-risk-level: "{{ k8s_ingress_nginx_load_balancer_annotations_risk_level }}"
   replicaCount: {{ k8s_ingress_nginx_replica_count }}

--- a/templates/ingress-nginx/chart-values-gcp.yaml
+++ b/templates/ingress-nginx/chart-values-gcp.yaml
@@ -7,4 +7,6 @@ controller:
   service:
     loadBalancerIP: "{{ k8s_ingress_nginx_load_balancer_ip }}"
 {% endif %}
+  config:
+    annotations-risk-level: "{{ k8s_ingress_nginx_load_balancer_annotations_risk_level }}"
   replicaCount: {{ k8s_ingress_nginx_replica_count }}

--- a/templates/ingress-nginx/chart-values-metallb.yaml
+++ b/templates/ingress-nginx/chart-values-metallb.yaml
@@ -8,4 +8,6 @@ controller:
     loadBalancerIP: "{{ k8s_ingress_nginx_load_balancer_ip }}"
 {% endif %}
     externalTrafficPolicy: Local  # required to see true client IP
+  config:
+    annotations-risk-level: "{{ k8s_ingress_nginx_load_balancer_annotations_risk_level }}"
   replicaCount: {{ k8s_ingress_nginx_replica_count }}


### PR DESCRIPTION
The 4.12.x ingress-nginx Helm chart upgrades the underlying ingress-nginx controller to version 1.12.0, which as noted in the [release notes](https://github.com/kubernetes/ingress-nginx/blob/4cbb78a9dc4f1888af802b70ddf980272e01268b/changelog/controller-1.12.0.md?plain=1#L148), includes adjusting the value of `annotations-risk-level` to "High" by default. This caused our services to return 404s when upgrading if using `configuration-snippet` or `server-snippet`

This PR allows configuring this value via an Ansible variable.

See kubernetes/ingress-nginx#13358 for more information.