### PR TITLE
Increase requests and response timeouts

### DIFF
--- a/templates/traefik/chart-values-aws.yaml
+++ b/templates/traefik/chart-values-aws.yaml
@@ -29,6 +29,11 @@ ports:
   web:
     port: 8000
     exposedPort: 80
+    transport:
+      respondingTimeouts:
+        readTimeout: "1800s" 
+        writeTimeout: "1800s"
+        idleTimeout: "180s"
     redirections:
       entryPoint:
         to: websecure
@@ -37,10 +42,15 @@ ports:
   websecure:
     port: 8443
     exposedPort: 443
+    ransport:
+      respondingTimeouts:
+        readTimeout: "1800s" 
+        writeTimeout: "1800s"
+        idleTimeout: "180s"
     asDefault: true
     tls:
       enabled: true
-      certResolver: "" 
+      certResolver: ""
 
 affinity: {{ k8s_traefik_affinity | to_json }}
 


### PR DESCRIPTION
Uploading huge files fail with the default timeouts. This was tested on the GP staging sites. Increasing the timeouts to 30 minutes.