### PR TITLE
Fix ALBC IAM Resources Static Names Bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ This project uses [semantic versioning](https://semver.org/).
 
 ## Changes
 
+### v1.10.1 on April 27, 2026
+
+**Bug Fix**
+
+* Migrates AWS Load Balancer Controller IAM resources from static to dynamic naming. This Prevents OIDC issuer trust policy conflicts in AWS accounts with multiple EKS clusters.
+
 ### v1.10.0 on April 15, 2026
 Add Traefik Ingress support
 * **Traefik Integration**: Support for Traefik alongside or as a replacement for Nginx.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This project uses [semantic versioning](https://semver.org/).
 
 * Migrates AWS Load Balancer Controller IAM resources from static to dynamic naming. This Prevents OIDC issuer trust policy conflicts in AWS accounts with multiple EKS clusters.
 
+* Adds the `k8s_web_cluster_role_install_traefik` toggle which defaults to `true`. This allows skipping Traefik deployment in specific environments via the role, where it is managed via other workflows.
+
 ### v1.10.0 on April 15, 2026
 Add Traefik Ingress support
 * **Traefik Integration**: Support for Traefik alongside or as a replacement for Nginx.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,9 @@ k8s_echotest_letsencrypt_issuer: 'letsencrypt-staging'
 # Values should be the IAM usernames (e.g. "johndev") and not anything more complicated.
 k8s_iam_users: []
 
+# When set to true, Traefik will be deployed using the k8s-web-cluster ansible role.
+k8s_web_cluster_role_install_traefik: true
+
 # Traefik deployment defaults
 k8s_traefik_namespace: "traefik"
 k8s_traefik_chart_version: "v38.0.2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -186,7 +186,7 @@
     api_version: v1
     kind: Namespace
     state: present
-  when: k8s_cluster_type != "libya"
+  when: k8s_web_cluster_role_install_traefik
 
 - name: Add Traefik Helm chart
   tags: traefik
@@ -200,4 +200,4 @@
     release_namespace: "{{ k8s_traefik_namespace }}"
     release_values: "{{ k8s_traefik_release_values | default(lookup('template', 'traefik/chart-values-%s.yaml' % k8s_cluster_type) | from_yaml) or omit }}"
     wait: yes
-  when: k8s_cluster_type != "libya"
+  when: k8s_web_cluster_role_install_traefik

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
   block:
     - name: Get AWS Account ID
       amazon.aws.aws_caller_info:
+        aws_profile: "{{ aws_profile | mandatory }}"
       register: caller_info
 
     - name: Fetch LBC Policy JSON from GitHub
@@ -37,14 +38,16 @@
 
     - name: Create IAM Policy for AWS Load Balancer Controller
       amazon.aws.iam_managed_policy:
-        policy_name: "AWSLoadBalancerControllerIAMPolicy"
+        aws_profile: "{{ aws_profile | mandatory }}"
+        policy_name: "{{ k8s_cluster_name }}-eks-aws-lbc-policy"
         state: present
         policy: "{{ aws_lbc_policy.content | from_json }}"
       register: iam_policy
 
     - name: Create IAM Role with Trust Relationship
       amazon.aws.iam_role:
-        role_name: "AWSLoadBalancerControllerRole"
+        aws_profile: "{{ aws_profile | mandatory }}"
+        role_name: "{{ k8s_cluster_name }}-eks-aws-lbc-role"
         state: present
         assume_role_policy_document: "{{ lookup('template', 'aws/trust-policy.json.j2') }}"
         managed_policies:
@@ -60,6 +63,8 @@
 
     - name: Create AWS Load Balancer Controller ServiceAccount
       kubernetes.core.k8s:
+        context: "{{ k8s_context|mandatory }}"
+        kubeconfig: "{{ k8s_kubeconfig }}"
         state: present
         definition:
           apiVersion: v1
@@ -85,8 +90,7 @@
             create: false
             name: aws-load-balancer-controller
         wait: yes
-
-  when: k8s_cluster_type == "aws"
+  when: "'aws' in k8s_cluster_type"
 
 - name: Apply Descheduler Helm chart
   kubernetes.core.helm:
@@ -182,6 +186,7 @@
     api_version: v1
     kind: Namespace
     state: present
+  when: k8s_cluster_type != "libya"
 
 - name: Add Traefik Helm chart
   tags: traefik
@@ -195,3 +200,4 @@
     release_namespace: "{{ k8s_traefik_namespace }}"
     release_values: "{{ k8s_traefik_release_values | default(lookup('template', 'traefik/chart-values-%s.yaml' % k8s_cluster_type) | from_yaml) or omit }}"
     wait: yes
+  when: k8s_cluster_type != "libya"


### PR DESCRIPTION
Migrates AWS Load Balancer Controller IAM resources from static to dynamic naming. This Prevents OIDC issuer trust policy conflicts in AWS accounts with multiple EKS clusters.

Part of https://app.clickup.com/t/868gdg425