### PR TITLE
Purge orphaned ingress validatingwebhookconfiguration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,10 @@ This project uses [semantic versioning](https://semver.org/).
 
 ## Changes
 
-### v1.11.0 on April 30, 2026
+### v1.11.0 on May 1, 2026
 
-* Bump Traefik helm chart to v39.0.8
+* Bump Traefik helm chart to v39.0.8.
+* Bug Fix: Update mandatory.yaml to delete orphaned ValidatingWebhookConfiguration resource.
 
 ### v1.10.1 on April 27, 2026
 

--- a/README.md
+++ b/README.md
@@ -233,3 +233,12 @@ k8s_traefik_affinity:
           topologyKey: "kubernetes.io/hostname"
 
 ```
+
+### Note
+For Macbook users, in case you hit the following error when running the following task, `tasks/main.yml`, run `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`.
+
+```
+TASK [caktus.k8s-web-cluster : Download and Apply Traefik CRDs] ****************************************************************************************************************************************************************************
+objc[43681]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
+objc[43681]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
+```

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -199,6 +199,7 @@
     url: "https://api.github.com/repos/traefik/traefik-helm-chart/contents/traefik/crds?ref={{ k8s_traefik_chart_version }}"
     return_content: yes
   register: crd_list
+  when: k8s_web_cluster_role_install_traefik
 
 # Download the CRD manifests and apply them.
 - name: Download and Apply Traefik CRDs

--- a/templates/ingress-nginx/mandatory.yaml
+++ b/templates/ingress-nginx/mandatory.yaml
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole
@@ -106,7 +106,7 @@ rules:
       - update
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nginx-ingress-role
@@ -151,7 +151,7 @@ rules:
       - get
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding
@@ -169,7 +169,7 @@ subjects:
     namespace: ingress-nginx
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-nisa-binding

--- a/templates/ingress-nginx/mandatory.yaml
+++ b/templates/ingress-nginx/mandatory.yaml
@@ -270,3 +270,12 @@ spec:
               exec:
                 command:
                   - /wait-shutdown
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: ingress-nginx-admission
+webhooks:
+  - name: validate.nginx.ingress.kubernetes.io


### PR DESCRIPTION
### ISSUE: https://github.com/caktus/ansible-role-k8s-web-cluster/issues/40

- [x] Deletes ingress-nginx validatingwebhookconfiguration  when purging ingress-nginx
- [x] Add conditional check for downloading Traefik CRDs from github